### PR TITLE
Fix racing/wheel animations and add Fish & Horse race modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
+.claude/
 .DS_Store
 *.suo
 *.ntvs*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🍀 Lucky Draw - PWA Random Name Picker
 
-A modern, fully responsive Progressive Web App (PWA) built with React for running lucky draw events. Features engaging animations with two modes: Wheel of Names and Racing Car simulator.
+A modern, fully responsive Progressive Web App (PWA) built with React for running lucky draw events. Features engaging animations with multiple modes: Wheel of Names and Racing simulators (Car, Fish, and Horse).
 
 ![Lucky Draw](https://img.shields.io/badge/PWA-Ready-brightgreen)
 ![React](https://img.shields.io/badge/React-19.2-blue)
@@ -13,7 +13,9 @@ A modern, fully responsive Progressive Web App (PWA) built with React for runnin
 - **🎯 Two Draw Modes**:
   - **🎡 Wheel of Names**: Animated spinning wheel with colorful segments
   - **🏎️ Racing Car**: Exciting race simulation with Top 3 podium display
-- **⏱️ Customizable Duration**: Adjust draw duration from 10 to 180 seconds
+  - **🐟 Fish Race**: Same race, themed with fish swimming across water lanes
+  - **🐎 Horse Race**: Same race, themed with horses galloping across the field
+- **⏱️ Customizable Duration**: Adjust draw duration from 5 to 180 seconds
 - **🎉 Winner Effects**: Confetti animations and visual celebrations
 - **🔄 Smart Options**: Toggle to remove winners from subsequent draws (Wheel mode)
 
@@ -92,7 +94,7 @@ npm run deploy
    - Or upload a CSV file with names
    
 2. **Select Mode**:
-   - Choose between Wheel of Names or Racing Car mode
+   - Choose between Wheel of Names or a Racing mode (Car, Fish, or Horse)
    
 3. **Set Duration**:
    - Adjust the animation duration (default: 60 seconds)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,9 @@ import WheelOfNames from './components/WheelOfNames';
 import RacingCar from './components/RacingCar';
 import WinnerDisplay from './components/WinnerDisplay';
 
+// Maps a racing-style mode to the visual theme used by RacingCar.
+const RACING_THEMES = { racing: 'car', fish: 'fish', horse: 'horse' };
+
 function App() {
   const [names, setNames] = useState([]);
   const [mode, setMode] = useState('wheel'); // 'wheel' or 'racing'
@@ -75,25 +78,25 @@ function App() {
       )}
 
       {isDrawing && mode === 'wheel' && (
-        <WheelOfNames 
-          names={names} 
-          duration={duration} 
+        <WheelOfNames
+          names={names}
+          duration={duration}
           onComplete={handleComplete}
         />
       )}
 
-      {isDrawing && mode === 'racing' && (
-        <RacingCar 
-          names={names} 
-          duration={duration} 
+      {isDrawing && mode !== 'wheel' && (
+        <RacingCar
+          names={names}
+          duration={duration}
+          theme={RACING_THEMES[mode]}
           onComplete={handleComplete}
         />
       )}
 
       {winner && !isDrawing && (
-        <WinnerDisplay 
-          winner={winner} 
-          mode={mode} 
+        <WinnerDisplay
+          winner={winner}
           onReset={handleReset}
         />
       )}

--- a/src/components/DurationSettings.jsx
+++ b/src/components/DurationSettings.jsx
@@ -17,7 +17,7 @@ function DurationSettings({ duration, setDuration }) {
       
       <input
         type="range"
-        min="10"
+        min="5"
         max="180"
         step="5"
         value={duration}

--- a/src/components/ModeSelector.jsx
+++ b/src/components/ModeSelector.jsx
@@ -1,26 +1,28 @@
 import './ModeSelector.css';
 
+const MODES = [
+  { id: 'wheel', icon: '🎡', title: 'Wheel of Names', desc: 'Spinning wheel animation' },
+  { id: 'racing', icon: '🏎️', title: 'Racing Car', desc: 'Race to the finish with Top 3' },
+  { id: 'fish', icon: '🐟', title: 'Fish Race', desc: 'Swim to the finish with Top 3' },
+  { id: 'horse', icon: '🐎', title: 'Horse Race', desc: 'Gallop to the finish with Top 3' },
+];
+
 function ModeSelector({ mode, setMode }) {
   return (
     <div className="mode-selector-container">
       <h2>Select Draw Mode</h2>
       <div className="mode-options">
-        <div
-          className={`mode-option ${mode === 'wheel' ? 'active' : ''}`}
-          onClick={() => setMode('wheel')}
-        >
-          <div className="mode-icon">🎡</div>
-          <h3>Wheel of Names</h3>
-          <p>Spinning wheel animation</p>
-        </div>
-        <div
-          className={`mode-option ${mode === 'racing' ? 'active' : ''}`}
-          onClick={() => setMode('racing')}
-        >
-          <div className="mode-icon">🏎️</div>
-          <h3>Racing Car</h3>
-          <p>Race to the finish with Top 3</p>
-        </div>
+        {MODES.map((m) => (
+          <div
+            key={m.id}
+            className={`mode-option ${mode === m.id ? 'active' : ''}`}
+            onClick={() => setMode(m.id)}
+          >
+            <div className="mode-icon">{m.icon}</div>
+            <h3>{m.title}</h3>
+            <p>{m.desc}</p>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/RacingCar.css
+++ b/src/components/RacingCar.css
@@ -83,16 +83,79 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 50px;
-  height: 40px;
-  border-radius: 8px;
+  transition: left 0.08s linear;
+  will-change: left;
+}
+
+.race-car-body {
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 50px;
+  height: 40px;
+  border-radius: 8px;
   font-size: 1.8rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  transition: left 0.05s linear;
-  will-change: left;
+  animation: bobCar 0.35s ease-in-out infinite;
+}
+
+/* Emojis (car, fish, horse) point left by default. Flip them so the racer
+   faces the finish line it is moving toward. */
+.race-car-emoji {
+  display: inline-block;
+  transform: scaleX(-1);
+  line-height: 1;
+}
+
+@keyframes bobCar {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+/* Fish gently sway as they swim. */
+.theme-fish .race-car-body {
+  animation: bobFish 0.7s ease-in-out infinite;
+}
+
+@keyframes bobFish {
+  0%, 100% {
+    transform: translateY(0) rotate(-4deg);
+  }
+  50% {
+    transform: translateY(-4px) rotate(4deg);
+  }
+}
+
+/* Horses bounce with a galloping rhythm. */
+.theme-horse .race-car-body {
+  animation: bobHorse 0.4s ease-in-out infinite;
+}
+
+@keyframes bobHorse {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  35% {
+    transform: translateY(-7px);
+  }
+  60% {
+    transform: translateY(0);
+  }
+}
+
+/* Themed lane surfaces. */
+.theme-fish .lane-track {
+  background: linear-gradient(to bottom, #BAE6FD 0%, #7DD3FC 45%, #38BDF8 55%, #7DD3FC 100%);
+  border-color: #38BDF8;
+}
+
+.theme-horse .lane-track {
+  background: linear-gradient(to bottom, #D9F99D 0%, #A3E635 45%, #C7A17A 45%, #C7A17A 55%, #A3E635 55%, #D9F99D 100%);
+  border-color: #A3E635;
 }
 
 .racing-text {
@@ -134,7 +197,7 @@
     height: 40px;
   }
 
-  .race-car {
+  .race-car-body {
     width: 40px;
     height: 32px;
     font-size: 1.5rem;
@@ -177,7 +240,7 @@
     height: 35px;
   }
 
-  .race-car {
+  .race-car-body {
     width: 35px;
     height: 28px;
     font-size: 1.2rem;

--- a/src/components/RacingCar.jsx
+++ b/src/components/RacingCar.jsx
@@ -1,221 +1,145 @@
 import { useEffect, useState, useRef } from 'react';
-import { motion } from 'framer-motion';
 import './RacingCar.css';
 
-function RacingCar({ names, duration, onComplete }) {
-  const [progress, setProgress] = useState({});
-  const [finished, setFinished] = useState([]);
-  const [isRacing, setIsRacing] = useState(false);
-  const animationRef = useRef(null);
-  const startTimeRef = useRef(null);
+const LANE_COLORS = [
+  '#EF4444', '#F59E0B', '#10B981', '#3B82F6', '#8B5CF6',
+  '#EC4899', '#14B8A6', '#F97316', '#06B6D4', '#6366F1'
+];
 
-  const colors = [
-    '#EF4444', '#F59E0B', '#10B981', '#3B82F6', '#8B5CF6',
-    '#EC4899', '#14B8A6', '#F97316', '#06B6D4', '#6366F1'
-  ];
+// Each racing mode reuses the same mechanics with a different look & feel.
+const THEMES = {
+  car: {
+    emojis: ['🏎️', '🚗', '🚙', '🚕', '🏁'],
+    text: '🏁 Racing to the finish...',
+  },
+  fish: {
+    emojis: ['🐟', '🐠', '🐡', '🦈', '🐬'],
+    text: '🐟 Swimming to the finish...',
+  },
+  horse: {
+    emojis: ['🐎', '🐴', '🦄', '🦓', '🏇'],
+    text: '🐎 Galloping to the finish...',
+  },
+};
 
-  const carEmojis = ['🏎️', '🚗', '🚙', '🚕', '🏁'];
+// Smooth ease-in-out so cars accelerate and settle naturally.
+const easeInOut = (t) =>
+  t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+
+function RacingCar({ names, duration, onComplete, theme = 'car' }) {
+  const { emojis, text } = THEMES[theme] || THEMES.car;
+  // Progress is keyed by car index (not name) so duplicate names still race
+  // independently.
+  const [progress, setProgress] = useState([]);
+  // RacingCar only renders while a race is in progress, so it starts racing.
+  const [isRacing, setIsRacing] = useState(true);
+  // Keep the latest onComplete without restarting the race when it changes.
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
 
   useEffect(() => {
-    const startRace = () => {
-    setIsRacing(true);
-    startTimeRef.current = Date.now();
-    
-    // Select a random winner at the start
-    const winnerIndex = Math.floor(Math.random() * names.length);
-    
-    const raceDuration = duration * 1000; // Convert to milliseconds
-    
-    // Calculate number of phases based on duration
-    // More duration = more phases for smoother transitions
-    // Min 3 phases, max 8 phases
-    const numPhases = Math.min(Math.max(Math.floor(duration / 5), 3), 8);
-    const phaseInterval = raceDuration / numPhases;
-    
-    // Generate initial positions with small random variance (0-5%)
-    const initialPositions = names.map(() => Math.random() * 5);
-    
-    // Generate velocity profiles for each phase
-    // Each car gets different velocities per phase
-    const velocityProfiles = names.map((_, index) => {
-      const profile = [];
-      for (let phase = 0; phase < numPhases; phase++) {
-        if (index === winnerIndex) {
-          // Winner: moderate speed early, dramatic acceleration in final phases
-          if (phase < numPhases - 2) {
-            // Early and mid phases: moderate speed with variations
-            profile.push(15 + Math.random() * 5); // 15-20% progress per phase
-          } else if (phase === numPhases - 2) {
-            // Second to last phase: start accelerating
-            profile.push(20 + Math.random() * 5); // 20-25% progress
-          } else {
-            // Final phase: maximum acceleration
-            profile.push(30 + Math.random() * 10); // 30-40% progress (dramatic finish)
-          }
-        } else {
-          // Non-winners: varied speeds that slow down near the end
-          if (phase < numPhases - 2) {
-            // Early and mid phases: random competitive speeds
-            profile.push(12 + Math.random() * 8); // 12-20% progress per phase
-          } else {
-            // Final phases: significant slowdown
-            profile.push(5 + Math.random() * 5); // 5-10% progress (letting winner pass)
-          }
-        }
-      }
-      return profile;
-    });
-    
-    // Calculate target positions for each phase
-    const phaseTargets = names.map((_, carIndex) => {
-      const targets = [initialPositions[carIndex]];
-      let cumulativeProgress = initialPositions[carIndex];
-      
-      for (let phase = 0; phase < numPhases; phase++) {
-        cumulativeProgress += velocityProfiles[carIndex][phase];
-        // Cap non-winners at 97% until final calculation
-        if (carIndex !== winnerIndex) {
-          targets.push(Math.min(cumulativeProgress, 97));
-        } else {
-          targets.push(Math.min(cumulativeProgress, 100));
-        }
-      }
-      
-      return targets;
-    });
-    
-    // Smooth oscillation for overtaking effect
-    const oscillationFreqs = names.map(() => 0.5 + Math.random() * 1.5);
-    const oscillationAmps = names.map(() => 1 + Math.random() * 2);
-    const oscillationPhases = names.map(() => Math.random() * Math.PI * 2);
-    
-    const animate = () => {
-      const elapsed = Date.now() - startTimeRef.current;
-      const progressPercent = Math.min(elapsed / raceDuration, 1);
-      
-      // Determine current phase
-      const currentPhaseFloat = (elapsed / phaseInterval);
-      const currentPhase = Math.floor(currentPhaseFloat);
-      const phaseProgress = currentPhaseFloat - currentPhase;
-      
-      const newProgress = {};
-      const newFinished = [];
+    if (names.length === 0) return undefined;
 
-      names.forEach((name, index) => {
-        let carProgress = 0;
-        
-        // Interpolate between current and next phase target
-        if (currentPhase >= numPhases) {
-          // Race finished
-          carProgress = phaseTargets[index][numPhases];
-        } else {
-          const currentTarget = phaseTargets[index][currentPhase];
-          const nextTarget = phaseTargets[index][currentPhase + 1];
-          
-          // Smooth interpolation between phase targets using easing
-          // Use ease-in-out for smooth transitions
-          const easeProgress = phaseProgress < 0.5
-            ? 2 * phaseProgress * phaseProgress
-            : 1 - Math.pow(-2 * phaseProgress + 2, 2) / 2;
-          
-          carProgress = currentTarget + (nextTarget - currentTarget) * easeProgress;
-        }
-        
-        // Add subtle oscillation for realistic overtaking/jostling
-        // Oscillation dampens as race progresses
-        const oscillation = Math.sin(
-          elapsed * oscillationFreqs[index] / 1000 + oscillationPhases[index]
-        ) * oscillationAmps[index] * (1 - progressPercent * 0.7);
-        
-        carProgress += oscillation;
-        
-        // Clamp progress to valid range
-        carProgress = Math.max(0, Math.min(carProgress, 100));
-        
-        // Set final progress
-        if (index === winnerIndex && progressPercent >= 1) {
-          newProgress[name] = 100;
-          if (!finished.includes(name)) {
-            newFinished.push({ name, position: 1 });
-          }
-        } else {
-          // Non-winners capped at 97% until race ends, then set final position
-          if (progressPercent >= 1) {
-            newProgress[name] = Math.min(carProgress, 97);
-          } else {
-            newProgress[name] = carProgress;
-          }
-        }
+    // Pick the winner up front so the finish is deterministic.
+    const winnerIndex = Math.floor(Math.random() * names.length);
+    const raceDuration = Math.max(duration, 1) * 1000;
+
+    // Each car gets a final position. The winner reaches the finish line (100%);
+    // everyone else finishes behind, spread out in a random order.
+    const nonWinners = names
+      .map((_, i) => i)
+      .filter((i) => i !== winnerIndex)
+      .sort(() => Math.random() - 0.5);
+
+    const targets = new Array(names.length);
+    targets[winnerIndex] = 100;
+    nonWinners.forEach((carIndex, rank) => {
+      const spread = nonWinners.length > 1 ? rank / (nonWinners.length - 1) : 0;
+      // Finishes fan out between ~92% (just behind) and ~60% (trailing).
+      targets[carIndex] = 92 - spread * 32 + (Math.random() * 4 - 2);
+    });
+
+    // Per-car pacing: the winner lags early and surges late for a dramatic
+    // finish; rivals get off the line quickly, then level off.
+    const pace = names.map((_, i) =>
+      i === winnerIndex ? 1.3 + Math.random() * 0.3 : 0.85 + Math.random() * 0.25
+    );
+
+    // Subtle wobble creates mid-race jostling/overtaking that settles by the end.
+    const wobbleFreq = names.map(() => 1 + Math.random() * 2);
+    const wobblePhase = names.map(() => Math.random() * Math.PI * 2);
+    const wobbleAmp = names.map(() => 2 + Math.random() * 3);
+
+    const startTime = performance.now();
+    let frameId = null;
+
+    const animate = (now) => {
+      const u = Math.min((now - startTime) / raceDuration, 1);
+      const newProgress = names.map((_, i) => {
+        const eased = easeInOut(Math.min(Math.pow(u, pace[i]), 1));
+        const base = targets[i] * eased;
+        const wobble =
+          Math.sin(u * Math.PI * 2 * wobbleFreq[i] + wobblePhase[i]) *
+          wobbleAmp[i] *
+          (1 - u);
+        // Once the race is over, pin to exact targets so the visual order
+        // matches the reported results.
+        if (u >= 1) return targets[i];
+        return Math.max(0, Math.min(base + wobble, 100));
       });
 
       setProgress(newProgress);
-      
-      if (newFinished.length > 0 && finished.length === 0) {
-        setFinished(newFinished);
-      }
 
-      if (progressPercent < 1) {
-        animationRef.current = requestAnimationFrame(animate);
+      if (u < 1) {
+        frameId = requestAnimationFrame(animate);
       } else {
         setIsRacing(false);
-        
-        // Calculate final positions based on final progress
-        const finalResults = names.map((name, index) => ({
-          name,
-          progress: newProgress[name],
-          index
-        })).sort((a, b) => b.progress - a.progress);
-        
-        const top3 = finalResults.slice(0, 3).map((result, pos) => ({
-          name: result.name,
-          position: pos + 1
-        }));
-        
-        onComplete(top3[0].name, top3);
+        const ranking = names
+          .map((name, i) => ({ name, position: targets[i] }))
+          .sort((a, b) => b.position - a.position);
+        const top3 = ranking
+          .slice(0, 3)
+          .map((racer, idx) => ({ name: racer.name, position: idx + 1 }));
+        onCompleteRef.current(top3[0].name, top3);
       }
     };
 
-    animationRef.current = requestAnimationFrame(animate);
-  };
+    frameId = requestAnimationFrame(animate);
 
-    startRace();
-    
     return () => {
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [names, duration]);
 
   return (
-    <div className="racing-container">
+    <div className={`racing-container theme-${theme}`}>
       <div className="race-track">
         <div className="finish-line">
           <div className="finish-flag">🏁</div>
         </div>
-        
+
         {names.map((name, index) => (
-          <div key={name} className="race-lane">
+          <div key={index} className="race-lane">
             <div className="lane-name">{name}</div>
             <div className="lane-track">
-              <motion.div
+              <div
                 className="race-car"
-                style={{
-                  backgroundColor: colors[index % colors.length],
-                  left: `${progress[name] || 0}%`
-                }}
-                animate={{
-                  y: [0, -3, 0],
-                }}
-                transition={{
-                  duration: 0.3,
-                  repeat: Infinity,
-                  ease: "easeInOut"
-                }}
+                style={{ left: `${progress[index] || 0}%` }}
               >
-                {carEmojis[index % carEmojis.length]}
-              </motion.div>
+                <span
+                  className="race-car-body"
+                  style={{ backgroundColor: LANE_COLORS[index % LANE_COLORS.length] }}
+                >
+                  {/* Emojis face left by default; flip them to face the finish line. */}
+                  <span className="race-car-emoji">
+                    {emojis[index % emojis.length]}
+                  </span>
+                </span>
+              </div>
             </div>
           </div>
         ))}
@@ -223,7 +147,7 @@ function RacingCar({ names, duration, onComplete }) {
 
       {isRacing && (
         <div className="racing-text">
-          <p>🏁 Racing to the finish...</p>
+          <p>{text}</p>
         </div>
       )}
     </div>

--- a/src/components/WheelOfNames.jsx
+++ b/src/components/WheelOfNames.jsx
@@ -76,9 +76,11 @@ function WheelOfNames({ names, duration, onComplete }) {
     // Calculate winner first
     winnerIndex.current = Math.floor(Math.random() * names.length);
     
-    // Calculate rotation to land on winner
+    // Calculate rotation to land the winning slice under the pointer, which
+    // sits at the top of the wheel (270° in canvas coordinates, where 0° is at
+    // 3 o'clock and angles increase clockwise).
     const anglePerSlice = 360 / names.length;
-    const targetAngle = 360 - (winnerIndex.current * anglePerSlice) - (anglePerSlice / 2);
+    const targetAngle = 270 - (winnerIndex.current * anglePerSlice) - (anglePerSlice / 2);
     
     // Dynamic spin count based on number of names for realistic effect
     // More names = more spins to show them all

--- a/src/components/WinnerDisplay.jsx
+++ b/src/components/WinnerDisplay.jsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import confetti from 'canvas-confetti';
 import './WinnerDisplay.css';
 
-function WinnerDisplay({ winner, mode, onReset }) {
+function WinnerDisplay({ winner, onReset }) {
   useEffect(() => {
     const triggerConfetti = () => {
     const duration = 3000;
@@ -37,15 +37,15 @@ function WinnerDisplay({ winner, mode, onReset }) {
   }, []);
 
   const renderWinnerContent = () => {
-    if (mode === 'racing' && Array.isArray(winner)) {
-      // Show Top 3 for racing mode
+    if (Array.isArray(winner)) {
+      // Show Top 3 for any racing-style mode (car, fish, horse)
       return (
         <div className="top-three-container">
           <h1 className="winner-title">🏁 Race Results</h1>
           <div className="podium">
             {winner.map((racer, index) => (
               <motion.div
-                key={racer.name}
+                key={racer.position}
                 className={`podium-place place-${racer.position}`}
                 initial={{ y: 100, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}


### PR DESCRIPTION
## Summary

Comprehensive bug review + two new race modes.

### 🐞 Bug fixes

**Racing Car — "car stands still" (reported bug)**
- The old phase/velocity math didn't scale with the phase count: short races ended with cars mid-track, and long races made cars slam into the 97/100% cap and **sit frozen** for most of the duration. Rewrote the movement model — cars now interpolate smoothly toward per-racer targets, and the winner surges to the finish line for a dramatic ending.
- **Vertical centering:** framer-motion's `y` animation was overwriting the CSS `translateY(-50%)`, pushing cars off the track line. Replaced with a plain positioned element + CSS bob.
- **Cars facing backwards:** emojis point left by default but move right, so they looked like they were driving in reverse. Flipped with `scaleX(-1)` to face the finish line.
- **Duplicate names:** keyed cars/progress by index instead of name, so duplicate names race independently (also removes duplicate React keys).

**Wheel of Names — wrong winner shown**
- The winning slice landed at 3 o'clock while the pointer sits at the top, so the wheel visually pointed at a *different* name than announced (verified: announced "East" but pointer on "North"). Now lands the slice under the top pointer (270°). Verified across multiple spins.

**Duration slider**
- `min` was `10` but the default and lowest preset are `5`, so the thumb stuck at 10 while the display read 5. Changed `min` to `5`.

### ✨ New modes
- **🐟 Fish Race** and **🐎 Horse Race** — reuse the racing mechanics with themed emojis, lane surfaces (water / grass+dirt), bob animations (sway / gallop), and captions.
- `WinnerDisplay` now shows the podium for any array result (car/fish/horse), not just the car mode.

### ✅ Verification
- `npm run lint` clean, `npm run build` succeeds.
- Drove all modes in-browser: racing motion, winner reaching the finish, wheel pointer alignment (3 spins), duplicate-name independence, fish/horse themes + emoji flip + podium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
