### PR TITLE
Add downloadable CSV template for name upload

### DIFF
--- a/src/components/NameInput.css
+++ b/src/components/NameInput.css
@@ -57,6 +57,29 @@
   cursor: not-allowed;
 }
 
+.upload-hint {
+  margin: 10px 0 0 0;
+  font-size: 0.85rem;
+  color: #6B7280;
+  line-height: 1.5;
+}
+
+.template-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.template-link:hover {
+  color: var(--primary-dark);
+}
+
 .names-list {
   margin-top: 20px;
   padding: 15px;

--- a/src/components/NameInput.jsx
+++ b/src/components/NameInput.jsx
@@ -28,6 +28,22 @@ function NameInput({ names, setNames }) {
     setNames([]);
   };
 
+  const handleDownloadTemplate = () => {
+    // One name per line matches how uploads are parsed and round-trips cleanly
+    // (a header row would be imported as a participant, so we omit one).
+    const sampleNames = ['Alice', 'Bob', 'Charlie', 'Diana', 'Ethan'];
+    const csvContent = sampleNames.join('\n') + '\n';
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'lucky-draw-template.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   const handleFileUpload = (e) => {
     const file = e.target.files[0];
     if (file) {
@@ -68,6 +84,17 @@ function NameInput({ names, setNames }) {
           />
         </label>
       </div>
+
+      <p className="upload-hint">
+        Uploading a CSV? Use one name per line (or comma-separated).{' '}
+        <button
+          type="button"
+          className="template-link"
+          onClick={handleDownloadTemplate}
+        >
+          ⬇ Download template
+        </button>
+      </p>
 
       {names.length > 0 && (
         <div className="names-list">


### PR DESCRIPTION
## Summary

Let users download a CSV template so they upload names in the correct format.

- Adds a **⬇ Download template** link under the Upload CSV button, with a short format hint ("one name per line, or comma-separated").
- Downloads `lucky-draw-template.csv` with sample names (`Alice`, `Bob`, `Charlie`, `Diana`, `Ethan`), one per line.
- No header row on purpose: the uploader splits on commas/newlines without skipping headers, so a header would be imported as a participant. The template round-trips through the parser exactly (verified → `[Alice, Bob, Charlie, Diana, Ethan]`, no stray empty entries).

### Verification
- `npm run lint` clean.
- Confirmed the download produces the right filename (`lucky-draw-template.csv`), MIME type (`text/csv`), and content.
- Confirmed the content re-parses cleanly through the existing upload parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
