### PR TITLE
Show racer icon + lane colour on results, add 50-colour palette, polish podium

### DIFF
--- a/src/components/RacingCar.jsx
+++ b/src/components/RacingCar.jsx
@@ -1,10 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
+import { RACER_COLORS } from '../palette';
 import './RacingCar.css';
-
-const LANE_COLORS = [
-  '#EF4444', '#F59E0B', '#10B981', '#3B82F6', '#8B5CF6',
-  '#EC4899', '#14B8A6', '#F97316', '#06B6D4', '#6366F1'
-];
 
 // Each racing mode reuses the same mechanics with a different look & feel.
 // Every racer in a mode shares one icon; lanes are told apart by colour.
@@ -102,11 +98,16 @@ function RacingCar({ names, duration, onComplete, theme = 'car' }) {
         intervalId = null;
         setIsRacing(false);
         const ranking = names
-          .map((name, i) => ({ name, position: targets[i] }))
-          .sort((a, b) => b.position - a.position);
-        const top3 = ranking
-          .slice(0, 3)
-          .map((racer, idx) => ({ name: racer.name, position: idx + 1 }));
+          .map((name, i) => ({ name, finalProgress: targets[i], laneIndex: i }))
+          .sort((a, b) => b.finalProgress - a.finalProgress);
+        const top3 = ranking.slice(0, 3).map((racer, idx) => ({
+          name: racer.name,
+          position: idx + 1,
+          // Carry each racer's icon and lane colour so the results can show
+          // the same visual identity people saw on the track.
+          emoji,
+          color: RACER_COLORS[racer.laneIndex % RACER_COLORS.length],
+        }));
         onCompleteRef.current(top3[0].name, top3);
       }
     };
@@ -119,7 +120,7 @@ function RacingCar({ names, duration, onComplete, theme = 'car' }) {
         clearInterval(intervalId);
       }
     };
-  }, [names, duration]);
+  }, [names, duration, emoji]);
 
   return (
     <div className={`racing-container theme-${theme}`}>
@@ -138,7 +139,7 @@ function RacingCar({ names, duration, onComplete, theme = 'car' }) {
               >
                 <span
                   className="race-car-body"
-                  style={{ backgroundColor: LANE_COLORS[index % LANE_COLORS.length] }}
+                  style={{ backgroundColor: RACER_COLORS[index % RACER_COLORS.length] }}
                 >
                   {/* Emojis face left by default; flip them to face the finish line. */}
                   <span className="race-car-emoji">

--- a/src/components/WheelOfNames.jsx
+++ b/src/components/WheelOfNames.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { motion } from 'framer-motion';
+import { RACER_COLORS } from '../palette';
 import './WheelOfNames.css';
 
 function WheelOfNames({ names, duration, onComplete }) {
@@ -8,10 +9,7 @@ function WheelOfNames({ names, duration, onComplete }) {
   const canvasRef = useRef(null);
   const winnerIndex = useRef(null);
 
-  const colors = [
-    '#EF4444', '#F59E0B', '#10B981', '#3B82F6', '#8B5CF6',
-    '#EC4899', '#14B8A6', '#F97316', '#06B6D4', '#6366F1'
-  ];
+  const colors = RACER_COLORS;
 
   useEffect(() => {
     const drawWheel = () => {

--- a/src/components/WinnerDisplay.css
+++ b/src/components/WinnerDisplay.css
@@ -74,52 +74,167 @@
   gap: 20px;
 }
 
+/* Wrapper: racer icon on top, coloured bar below. Columns bottom-align so the
+   bars form the podium tiers and the icons sit on top of each bar. */
 .podium-place {
-  background: white;
-  border-radius: 20px;
-  padding: 30px 20px;
-  text-align: center;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   min-width: 180px;
 }
 
+/* Podium ordering: 2nd on the left, 1st in the centre, 3rd on the right. */
 .place-1 {
   order: 2;
-  height: 300px;
-  background: linear-gradient(135deg, #FFD700, #FFA500);
 }
 
 .place-2 {
   order: 1;
-  height: 250px;
-  background: linear-gradient(135deg, #C0C0C0, #A8A8A8);
 }
 
 .place-3 {
   order: 3;
-  height: 200px;
-  background: linear-gradient(135deg, #CD7F32, #B87333);
+}
+
+/* Racer identity: the icon in its lane colour, sitting on top of the bar. */
+.place-racer {
+  width: 60px;
+  height: 60px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25);
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  margin-bottom: -18px; /* overlap onto the top of the bar */
+  position: relative;
+  z-index: 2;
+}
+
+.place-racer-emoji {
+  display: inline-block;
+  font-size: 2rem;
+  line-height: 1;
+  /* Match the direction the racer faced on the track. */
+  transform: scaleX(-1);
+}
+
+/* The coloured podium bar. Fixed height per rank creates the tiers; contents
+   are laid out top-to-bottom with the name pinned to the bottom. */
+.place-bar {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 20px;
+  /* Even top/bottom padding + space-between keeps the medal, number and name
+     spaced consistently across all three (differently sized) bars. */
+  padding: 30px 20px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+}
+
+/* Metallic sheen: a soft diagonal highlight (light top-left, shade
+   bottom-right) plus a slow shine that sweeps across for a polished look. */
+.place-bar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.45) 0%,
+    rgba(255, 255, 255, 0.05) 42%,
+    rgba(0, 0, 0, 0.12) 100%
+  );
+  pointer-events: none;
+}
+
+.place-bar::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -75%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(
+    100deg,
+    transparent,
+    rgba(255, 255, 255, 0.55),
+    transparent
+  );
+  transform: skewX(-20deg);
+  animation: podiumShine 3.5s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes podiumShine {
+  0% {
+    left: -75%;
+  }
+  55%, 100% {
+    left: 140%;
+  }
+}
+
+/* Keep the text above the sheen layers. */
+.place-medal,
+.place-position,
+.place-name {
+  position: relative;
+  z-index: 1;
+}
+
+.place-1 .place-bar {
+  height: 340px;
+  background: linear-gradient(160deg, #FFEF9E 0%, #FFD32A 32%, #F5A623 68%, #DC8912 100%);
+  box-shadow: 0 14px 36px rgba(224, 150, 20, 0.55),
+    inset 0 2px 8px rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 240, 170, 0.9);
+}
+
+.place-2 .place-bar {
+  height: 290px;
+  background: linear-gradient(160deg, #FBFBFB 0%, #D8DADE 32%, #AEB2B8 68%, #8A8F96 100%);
+  box-shadow: 0 14px 32px rgba(150, 155, 165, 0.5),
+    inset 0 2px 8px rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.85);
+}
+
+.place-3 .place-bar {
+  height: 240px;
+  background: linear-gradient(160deg, #F0B78E 0%, #D08843 34%, #B06F2E 70%, #8C5620 100%);
+  box-shadow: 0 14px 30px rgba(140, 86, 32, 0.5),
+    inset 0 2px 8px rgba(255, 235, 210, 0.5);
+  border: 1px solid rgba(240, 183, 142, 0.85);
+}
+
+/* Stagger the shine so the three bars sparkle in sequence. */
+.place-2 .place-bar::after {
+  animation-delay: 1.2s;
+}
+
+.place-3 .place-bar::after {
+  animation-delay: 2.4s;
 }
 
 .place-medal {
-  font-size: 4rem;
-  margin-bottom: 15px;
+  font-size: 3.2rem;
 }
 
 .place-position {
-  font-size: 2.5rem;
+  font-size: 2.8rem;
   font-weight: bold;
   color: white;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
-  margin-bottom: 10px;
 }
 
 .place-name {
   font-size: 1.5rem;
   font-weight: bold;
   color: white;
-  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.35);
   word-break: break-word;
 }
 
@@ -172,23 +287,26 @@
 
   .podium-place {
     min-width: 140px;
-    padding: 20px 15px;
   }
 
-  .place-1 {
+  .place-bar {
+    padding: 24px 15px 20px;
+  }
+
+  .place-1 .place-bar {
+    height: 300px;
+  }
+
+  .place-2 .place-bar {
     height: 250px;
   }
 
-  .place-2 {
+  .place-3 .place-bar {
     height: 200px;
   }
 
-  .place-3 {
-    height: 150px;
-  }
-
   .place-medal {
-    font-size: 3rem;
+    font-size: 2.6rem;
   }
 
   .place-position {
@@ -236,16 +354,19 @@
 
   .place-1 {
     order: 1;
-    height: auto;
   }
 
   .place-2 {
     order: 2;
-    height: auto;
   }
 
   .place-3 {
     order: 3;
+  }
+
+  .place-1 .place-bar,
+  .place-2 .place-bar,
+  .place-3 .place-bar {
     height: auto;
   }
 }

--- a/src/components/WinnerDisplay.jsx
+++ b/src/components/WinnerDisplay.jsx
@@ -51,13 +51,23 @@ function WinnerDisplay({ winner, onReset }) {
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ delay: index * 0.3, duration: 0.5 }}
               >
-                <div className="place-medal">
-                  {racer.position === 1 && '🥇'}
-                  {racer.position === 2 && '🥈'}
-                  {racer.position === 3 && '🥉'}
+                {racer.emoji && (
+                  <div
+                    className="place-racer"
+                    style={{ backgroundColor: racer.color }}
+                  >
+                    <span className="place-racer-emoji">{racer.emoji}</span>
+                  </div>
+                )}
+                <div className="place-bar">
+                  <div className="place-medal">
+                    {racer.position === 1 && '🥇'}
+                    {racer.position === 2 && '🥈'}
+                    {racer.position === 3 && '🥉'}
+                  </div>
+                  <div className="place-position">{racer.position}</div>
+                  <div className="place-name">{racer.name}</div>
                 </div>
-                <div className="place-position">{racer.position}</div>
-                <div className="place-name">{racer.name}</div>
               </motion.div>
             ))}
           </div>

--- a/src/palette.js
+++ b/src/palette.js
@@ -1,0 +1,14 @@
+// A palette of 50 visually distinct colors, shared by race lanes and wheel
+// segments so entries rarely repeat their colour.
+//
+// Hues are spread with the golden angle (~137.5°) so consecutive entries —
+// i.e. neighbouring lanes/segments — always land far apart on the colour
+// wheel and never look alike. Small, deterministic saturation/lightness
+// variation keeps same-family hues distinguishable while staying dark enough
+// for white text (used on the wheel).
+export const RACER_COLORS = Array.from({ length: 50 }, (_, i) => {
+  const hue = Math.round((i * 137.508) % 360);
+  const saturation = 60 + (i % 2) * 12; // 60% or 72%
+  const lightness = 44 + (i % 3) * 6; // 44%, 50% or 56%
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+});


### PR DESCRIPTION
## Summary

Make race results recognisable by racer identity, and give the podium a more polished, premium look.

### Race Results show racer identity
- Each podium place now shows the racer's **icon** (🏎️ / 🐟 / 🐎) in their **lane colour**, sitting on top of the bar — so people recognise winners by the colour/lane they watched, not just the name.
- `RacingCar` passes each top-3 racer's `emoji` + lane `color` through to `WinnerDisplay`.

### Shared 50-colour palette
- New `src/palette.js` with **50 distinct colours**, generated by golden-angle hue rotation so neighbouring lanes/segments never look alike.
- Used by **both** race lanes and wheel segments, replacing the two duplicated 10-colour arrays that repeated quickly with more entrants.

### Podium layout fix
- Previously the added icon pushed names out of the fixed-height bars. Reworked so the icon sits **on top** of the bar, and medal / number / name are spaced consistently inside, with names pinned to a **shared baseline** across all three bars.

### More striking Gold / Silver / Bronze
- Taller bars (340 / 290 / 240px, even 50px steps).
- Metallic multi-stop gradients, a diagonal gloss highlight, a colour-matched glow, and a slow **shine sweep** that animates across each bar in sequence.

### Verification
- `npm run lint` clean, `npm run build` succeeds.
- Verified in-browser (desktop + mobile): icons + lane colours on the podium, 50 unique colours, names aligned to a shared baseline, and the shine animation running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
