### PR TITLE
Bump CI build to Node.js 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Bump the GitHub Pages build step from Node.js 20 to the current LTS, Node.js 22.

- Node.js 20 is being phased out on GitHub Actions runners; using Node.js 22 keeps the build on a supported LTS.
- Only the `node-version` in the build's `setup-node` step changes.

Note: this does not remove the separate deprecation *warning* about `actions/deploy-pages@v4` running on Node 24 — that comes from GitHub's own action (already on its latest major `v4`) and is harmless; deploys still succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
